### PR TITLE
Source maps support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
-var CleanCSS = require('clean-css')
-var async = require('async')
-var minimatch = require('minimatch')
+const CleanCSS = require('clean-css')
+const async = require('async')
+const minimatch = require('minimatch')
 
 /**
  * A Metalsmith plugin to minify CSS files.
@@ -11,31 +11,62 @@ var minimatch = require('minimatch')
  * @param {Object=} options.cleanCSS - the options to pass to clean-css
  * @return {Function} - the Metalsmith plugin
  */
-module.exports = function plugin (options) {
+module.exports = (options) => {
   options =
     typeof options === 'object' && options ? options
                                            : {}
-
-  options.files =
-    typeof options.files === 'string' ? options.files
-                                      : '**/*.css'
 
   options.cleanCSS =
     typeof options.cleanCSS === 'object' && options.cleanCSS ? options.cleanCSS
                                                              : {}
 
-  var cleanCSS = new CleanCSS(options.cleanCSS)
+  options.pattern =
+    typeof options.files === 'string' ? options.files
+                                      : '**/*.css'
 
-  return function (files, metalsmith, done) {
-    async.each(Object.keys(files), function (filename, callback) {
-      if (!minimatch(filename, options.files)) {
+  options.sourceMap =
+    typeof options.sourceMap === 'boolean' ? options.sourceMap
+                                           : false
+
+  options.sourceMapInlineSources =
+    typeof options.sourceMapInlineSources === 'boolean' ? options.sourceMap
+                                                        : false
+
+  return (files, metalsmith, done) => {
+    // Instanciate the clean-css engine (with potential source maps support)
+    if (options.sourceMap) {
+      options.cleanCSS.sourceMap = true
+      options.cleanCSS.sourceMapInlineSources = options.sourceMapInlineSources
+      options.cleanCSS.target = metalsmith._directory
+    }
+    const cleanCSS = new CleanCSS(options.cleanCSS)
+    // Loop over all the files metalsmith knows of
+    async.each(Object.keys(files), (filepath, callback) => {
+      const file = files[filepath]
+      const sourceMapFilepath = `${filepath}.map`
+      const sourceMapFile = files[sourceMapFilepath] || {}
+      // Check whether the current file is concerned by the minification
+      if (!minimatch(filepath, options.pattern)) {
         return callback()
       }
-      cleanCSS.minify(files[filename].contents, function (error, minified) {
+      // Minify the file
+      cleanCSS.minify({
+        [filepath]: {
+          styles: file.contents,
+          sourceMap: file.sourceMap || sourceMapFile.contents || undefined
+        }
+      }, (error, minified) => {
         if (error) {
           return callback(error)
         }
-        files[filename].contents = minified.styles
+        // Update the file with the minified content
+        file.contents = minified.styles
+        // Expose the source map (so that it could be used by another plugin)
+        file.sourceMap = sourceMapFile.contents = JSON.stringify(minified.sourceMap)
+        // Expose the source map as a .map file if asked not to inline it
+        if (options.sourceMap && !options.sourceMapInlineSources) {
+          files[sourceMapFilepath] = sourceMapFile
+        }
         return callback()
       })
     }, done)

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,13 +59,16 @@ module.exports = (options) => {
         if (error) {
           return callback(error)
         }
-        // Update the file with the minified content
+        // Update the file contents with its minified version
         file.contents = minified.styles
-        // Expose the source map (so that it could be used by another plugin)
-        file.sourceMap = sourceMapFile.contents = JSON.stringify(minified.sourceMap)
-        // Expose the source map as a .map file if asked not to inline it
-        if (options.sourceMap && !options.sourceMapInlineSources) {
-          files[sourceMapFilepath] = sourceMapFile
+        // Deal with the source map
+        if (options.sourceMap && minified.sourceMap) {
+          // Expose the source map (so that it could be used by another plugin)
+          file.sourceMap = sourceMapFile.contents = JSON.stringify(minified.sourceMap)
+          // Expose the source map as a .map file if asked not to inline it
+          if (!options.sourceMapInlineSources) {
+            files[sourceMapFilepath] = sourceMapFile
+          }
         }
         return callback()
       })

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ module.exports = (options) => {
     if (options.sourceMap) {
       options.cleanCSS.sourceMap = true
       options.cleanCSS.sourceMapInlineSources = options.sourceMapInlineSources
-      options.cleanCSS.target = metalsmith._directory
+      options.cleanCSS.target = options.cleanCSS.target || metalsmith._directory
     }
     const cleanCSS = new CleanCSS(options.cleanCSS)
     // Loop over all the files metalsmith knows of

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ module.exports = (options) => {
                                            : false
 
   options.sourceMapInlineSources =
-    typeof options.sourceMapInlineSources === 'boolean' ? options.sourceMap
+    typeof options.sourceMapInlineSources === 'boolean' ? options.sourceMapInlineSources
                                                         : false
 
   return (files, metalsmith, done) => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23,9 +23,9 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
     },
     "clean-css": {
-      "version": "3.4.10",
-      "from": "clean-css@3.4.10",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.10.tgz"
+      "version": "3.4.11",
+      "from": "clean-css@3.4.11",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.11.tgz"
     },
     "commander": {
       "version": "2.8.1",
@@ -43,9 +43,9 @@
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "lodash": {
-      "version": "4.6.1",
+      "version": "4.7.0",
       "from": "lodash@>=4.3.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.7.0.tgz"
     },
     "minimatch": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "lib",
   "dependencies": {
     "async": "2.0.0-rc.2",
-    "clean-css": "3.4.10",
+    "clean-css": "3.4.11",
     "minimatch": "3.0.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,9 @@ The configuration object will be passed as is.
 
 ## Changelog
 
+* 3.1.0
+  * Bump clean-css@3.4.11
+
 * 3.0.2
   * Switch test suite to nyc + ava
 

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,14 @@ Metalsmith(__dirname)
 ;
 ```
 
+#### cleanCSS
+Type: `Object`
+Default: `{}`
+
+Allow you to directly manipulate the [clean-css
+API](https://github.com/GoalSmashers/clean-css#how-to-use-clean-css-programmatically).
+The configuration object will be passed as is.
+
 #### files
 Type: `String`
 Default: `**/*.css`
@@ -56,18 +64,33 @@ is directly passed to [minimatch](https://github.com/isaacs/minimatch). Each
 file matching the pattern will be minified in place using
 [clean-css](https://github.com/jakubpawlowicz/clean-css).
 
-#### cleanCSS
-Type: `Object`
-Default: `{}`
+#### sourceMaps
+Type: `Boolean`
+Default: `false`
 
-Allow you to directly manipulate the [clean-css
-API](https://github.com/GoalSmashers/clean-css#how-to-use-clean-css-programmatically).
-The configuration object will be passed as is.
+Whether the source maps should be kept after the minification. You can force to
+inline the source maps (without creating an extra `.map` file in the build) by
+setting `options.sourceMapsInlineSources` to `true`.
+
+This plugin supports the forwarding of existing source maps, it will first look
+for a `sourceMap` property on the file, then for `.map` file, and finally
+fallback to inline source maps.
+
+#### sourceMapsInlineSources
+Type: `Boolean`
+Default: `false`
+
+Whether the source maps should be inlined in each CSS file. If set to `true` the
+source maps will be inlined in each file, and no extra `.map` file will be
+generated.
 
 ## Changelog
 
-* 3.1.0
+* 4.0.0
+  * Only supports Node 4+
   * Bump clean-css@3.4.11
+  * Support input source maps as `file.sourceMap`, `${filepath}.map` and inline
+  * Support to generate source maps as `file.sourceMap` and `${filepath}.map`
 
 * 3.0.2
   * Switch test suite to nyc + ava


### PR DESCRIPTION
Close https://github.com/aymericbeaumet/metalsmith-clean-css/issues/1

cc @jakubpawlowicz:
- how does clean-css behave with inline source maps?
- i currently rebase all the url (via the `target` option) to the metalsmith src directory, wdyt?