### PR TITLE
Update minimatch to 3.0.3 to avoid warning

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -48,9 +48,9 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
     },
     "minimatch": {
-      "version": "3.0.0",
-      "from": "minimatch@3.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
+      "version": "3.0.3",
+      "from": "minimatch@3.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "source-map": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "async": "2.0.0-rc.6",
     "clean-css": "3.4.17",
-    "minimatch": "3.0.0"
+    "minimatch": "3.0.3"
   },
   "devDependencies": {
     "ava": "0.15.2",


### PR DESCRIPTION
Thanks for the plugin! Works really well. I just found a minor issue. If I install it I get the following message:

    warning metalsmith-clean-css > minimatch@3.0.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

So I updated minimatch to 3.0.3 which seems to be the latest version at the moment. All tests are running fine.